### PR TITLE
Bump org.apache.commons:commons-lang3 from 3.0 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.0</version>
+            <version>3.18.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.0 to 3.18.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-lang3 dependency-version: 3.18.0 dependency-type: direct:production ...