### PR TITLE
Bump commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.4</version>
+            <version>1.11.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0.

---
updated-dependencies:
- dependency-name: commons-beanutils:commons-beanutils dependency-version: 1.11.0 dependency-type: direct:production ...